### PR TITLE
remove wrong assert

### DIFF
--- a/libs/base/CNode.hpp
+++ b/libs/base/CNode.hpp
@@ -91,8 +91,6 @@ namespace UPGMpp
                                                              m_label ( label ),
                                                              m_handCodedPotentials( false )
         {
-            assert( features.rows() == type->getNumberOfFeatures() );
-
             m_id = setID();
 
             // Convert the vector of features into an eigen vector            


### PR DESCRIPTION
The variable `features` can be a std::vector here, which doesn't have
a member named `rows`.
